### PR TITLE
Track screens explicitly in Firebase

### DIFF
--- a/Integrations/analytics-ios-integration-firebase/Segment-FirebaseTests/Segment_FirebaseTests.m
+++ b/Integrations/analytics-ios-integration-firebase/Segment-FirebaseTests/Segment_FirebaseTests.m
@@ -559,6 +559,15 @@ describe(@"Firebase Integration", ^{
                                                                       @"search_term" : @"blue hotpants"
                                                                       }];
     });
+  
+    it(@"track screen with name", ^{
+        SEGScreenPayload *payload = [[SEGScreenPayload alloc] initWithName:@"Home screen"
+                                                                properties:@{}
+                                                                   context:@{}
+                                                              integrations:@{}];
+        [integration screen:payload];
+        [verify(mockFirebase) setScreenName:@"Home screen" screenClass:nil];
+    });
     
 });
 

--- a/Integrations/analytics-ios-integration-firebase/Source/Core/SEGFirebaseIntegration.m
+++ b/Integrations/analytics-ios-integration-firebase/Source/Core/SEGFirebaseIntegration.m
@@ -64,6 +64,13 @@
 }
 
 
+- (void)screen:(SEGScreenPayload *)payload
+{
+    [self.firebaseClass setScreenName:payload.name screenClass:nil];
+    SEGLog(@"[FIRAnalytics setScreenName:%@]", payload.name);
+}
+
+
 #pragma mark - Utilities
 
 // Event names can be up to 32 characters long, may only contain alphanumeric


### PR DESCRIPTION
Segment’s documentation mentions that screen events are not passed through to the Firebase SDK because Firebase does automatic screen tracking. (https://segment.com/docs/connections/destinations/catalog/firebase/#screen)
However, it mentions that Automatic+Manual screen tracking should be supported, but this currently does not work because Segment does not forward the manual screen tracking events. 

This change will allow explicitly tracked screens in analytics-react-native using `analytics.screen` to actually be tracked in Firebase.